### PR TITLE
Next

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,3 +99,4 @@ create_voucher
 Create_Random Sample
 
 Random sample nur für eine art
+# CI test

--- a/backend/src/backend/scripts/manage_records_cache.py
+++ b/backend/src/backend/scripts/manage_records_cache.py
@@ -1,0 +1,363 @@
+# Cache management script for records materialized views
+# Used in dashboard heatmap generation
+# Each cached table holds records for a specific site and year
+#
+#  Usage examples:
+#
+# Setup the database function (run once)
+# python manage_records_cache.py setup
+#
+# Refresh cache for site 1, year 2024
+# python manage_records_cache.py refresh 1 2024
+#
+# List all caches
+# python manage_records_cache.py list
+#
+# Get statistics for a specific cache
+# python manage_records_cache.py stats 1 2024
+#
+# Refresh all years for a site
+# python manage_records_cache.py refresh-site 1 --start-year 2020 --end-year 2024
+#
+# Drop a specific cache
+# python manage_records_cache.py drop 1 2024
+#
+# Drop all caches
+# python manage_records_cache.py drop-all
+
+import os
+import sys
+import argparse
+import psycopg2
+from psycopg2 import sql
+from datetime import datetime
+import logging
+from dotenv import load_dotenv
+
+# Load environment variables from .env file
+load_dotenv()
+
+# Setup logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+
+class RecordsCacheManager:
+    """Manage materialized views for caching records by site and year."""
+
+    def __init__(self):
+        """Initialize database connection from environment variables."""
+        # Retrieve database connection details from environment variables
+        db_username = os.getenv("DB_USERNAME")
+        db_password = os.getenv("DB_PASSWORD")
+        db_host = os.getenv("DB_HOST")
+        db_port = os.getenv("DB_PORT", "5432")
+        db_name = os.getenv("DB_NAME")
+
+        # Validate required environment variables
+        if not all([db_username, db_password, db_host, db_name]):
+            raise ValueError(
+                "Missing required environment variables. "
+                "Please ensure DB_USERNAME, DB_PASSWORD, DB_HOST, and DB_NAME are set."
+            )
+
+        self.conn = psycopg2.connect(
+            host=db_host,
+            port=db_port,
+            dbname=db_name,
+            user=db_username,
+            password=db_password
+        )
+        self.conn.autocommit = False
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.conn.close()
+
+    def create_refresh_function(self):
+        """Create the PostgreSQL function to manage materialized views."""
+        sql_function = """
+        CREATE OR REPLACE FUNCTION refresh_records_cache(
+            p_site_id INTEGER,
+            p_year INTEGER
+        ) RETURNS TEXT AS $$
+        DECLARE
+            view_name TEXT;
+            start_date TEXT;
+            end_date TEXT;
+        BEGIN
+            view_name := 'mv_records_site_' || p_site_id || '_year_' || p_year;
+            start_date := p_year || '-01-01T00:00:00';
+            end_date := (p_year + 1) || '-01-01T00:00:00';
+
+            -- Drop existing view if it exists
+            EXECUTE 'DROP MATERIALIZED VIEW IF EXISTS ' || view_name;
+
+            -- Create materialized view
+            EXECUTE format('
+                CREATE MATERIALIZED VIEW %I AS
+                SELECT id, record_datetime, site_id
+                FROM records
+                WHERE site_id = %L
+                  AND record_datetime >= %L
+                  AND record_datetime < %L
+                ORDER BY record_datetime ASC
+            ', view_name, p_site_id, start_date, end_date);
+
+            -- Create index
+            EXECUTE format('
+                CREATE INDEX idx_%I_id ON %I(id)
+            ', view_name, view_name);
+
+            -- Create datetime index for faster queries
+            EXECUTE format('
+                CREATE INDEX idx_%I_datetime ON %I(record_datetime)
+            ', view_name, view_name);
+
+            RAISE NOTICE 'Created materialized view: %', view_name;
+
+            RETURN view_name;
+        END;
+        $$ LANGUAGE plpgsql;
+        """
+
+        try:
+            with self.conn.cursor() as cur:
+                cur.execute(sql_function)
+                self.conn.commit()
+                logger.info("Successfully created refresh_records_cache function")
+        except Exception as e:
+            self.conn.rollback()
+            logger.error(f"Failed to create function: {e}")
+            raise
+
+    def refresh_cache(self, site_id, year):
+        """Create or refresh a materialized view for a specific site and year."""
+        view_name = f"mv_records_site_{site_id}_year_{year}"
+
+        try:
+            with self.conn.cursor() as cur:
+                cur.execute("SELECT refresh_records_cache(%s, %s)", (site_id, year))
+                result = cur.fetchone()[0]
+                self.conn.commit()
+                logger.info(f"Successfully refreshed cache: {result}")
+                return result
+        except Exception as e:
+            self.conn.rollback()
+            logger.error(f"Failed to refresh cache for site {site_id}, year {year}: {e}")
+            raise
+
+    def list_caches(self):
+        """List all existing record cache materialized views."""
+        query = """
+        SELECT schemaname, matviewname,
+               pg_size_pretty(pg_total_relation_size(schemaname||'.'||matviewname)) as size
+        FROM pg_matviews
+        WHERE matviewname LIKE 'mv_records_site_%'
+        ORDER BY matviewname;
+        """
+
+        try:
+            with self.conn.cursor() as cur:
+                cur.execute(query)
+                results = cur.fetchall()
+
+                if not results:
+                    logger.info("No record caches found")
+                    return []
+
+                logger.info(f"Found {len(results)} record caches:")
+                for schema, name, size in results:
+                    logger.info(f"  - {schema}.{name} ({size})")
+
+                return results
+        except Exception as e:
+            logger.error(f"Failed to list caches: {e}")
+            raise
+
+    def drop_cache(self, site_id, year):
+        """Drop a specific materialized view cache."""
+        view_name = f"mv_records_site_{site_id}_year_{year}"
+
+        try:
+            with self.conn.cursor() as cur:
+                cur.execute(sql.SQL("DROP MATERIALIZED VIEW IF EXISTS {}").format(
+                    sql.Identifier(view_name)
+                ))
+                self.conn.commit()
+                logger.info(f"Successfully dropped cache: {view_name}")
+        except Exception as e:
+            self.conn.rollback()
+            logger.error(f"Failed to drop cache {view_name}: {e}")
+            raise
+
+    def drop_all_caches(self):
+        """Drop all record cache materialized views."""
+        try:
+            with self.conn.cursor() as cur:
+                cur.execute("""
+                    SELECT matviewname
+                    FROM pg_matviews
+                    WHERE matviewname LIKE 'mv_records_site_%'
+                """)
+                views = cur.fetchall()
+
+                for (view_name,) in views:
+                    cur.execute(sql.SQL("DROP MATERIALIZED VIEW IF EXISTS {}").format(
+                        sql.Identifier(view_name)
+                    ))
+                    logger.info(f"Dropped cache: {view_name}")
+
+                self.conn.commit()
+                logger.info(f"Successfully dropped {len(views)} caches")
+        except Exception as e:
+            self.conn.rollback()
+            logger.error(f"Failed to drop all caches: {e}")
+            raise
+
+    def get_cache_stats(self, site_id, year):
+        """Get statistics about a specific cache."""
+        view_name = f"mv_records_site_{site_id}_year_{year}"
+
+        query = """
+        SELECT
+            COUNT(*) as record_count,
+            MIN(record_datetime) as earliest_record,
+            MAX(record_datetime) as latest_record,
+            pg_size_pretty(pg_total_relation_size(%s)) as size
+        FROM {}
+        """.format(sql.Identifier(view_name))
+
+        try:
+            with self.conn.cursor() as cur:
+                cur.execute(
+                    sql.SQL(query).format(sql.Identifier(view_name)),
+                    (view_name,)
+                )
+                result = cur.fetchone()
+
+                if result:
+                    stats = {
+                        'view_name': view_name,
+                        'record_count': result[0],
+                        'earliest_record': result[1],
+                        'latest_record': result[2],
+                        'size': result[3]
+                    }
+                    logger.info(f"Cache stats for {view_name}:")
+                    for key, value in stats.items():
+                        logger.info(f"  {key}: {value}")
+                    return stats
+                else:
+                    logger.warning(f"No data found for {view_name}")
+                    return None
+        except Exception as e:
+            logger.error(f"Failed to get cache stats: {e}")
+            raise
+
+    def refresh_all_for_site(self, site_id, start_year=None, end_year=None):
+        """Refresh all caches for a site across a range of years."""
+        if start_year is None:
+            start_year = 2020  # Default start year
+        if end_year is None:
+            end_year = datetime.now().year
+
+        logger.info(f"Refreshing caches for site {site_id}, years {start_year}-{end_year}")
+
+        for year in range(start_year, end_year + 1):
+            try:
+                self.refresh_cache(site_id, year)
+            except Exception as e:
+                logger.error(f"Failed to refresh cache for site {site_id}, year {year}: {e}")
+                continue
+
+
+def main():
+    """Main CLI interface."""
+    parser = argparse.ArgumentParser(
+        description='Manage materialized view caches for records'
+    )
+
+    subparsers = parser.add_subparsers(dest='command', help='Command to execute')
+
+    # Setup command
+    subparsers.add_parser('setup', help='Create the refresh function in the database')
+
+    # Refresh command
+    refresh_parser = subparsers.add_parser('refresh', help='Refresh a cache')
+    refresh_parser.add_argument('site_id', type=int, help='Site ID')
+    refresh_parser.add_argument('year', type=int, help='Year')
+
+    # List command
+    subparsers.add_parser('list', help='List all caches')
+
+    # Drop command
+    drop_parser = subparsers.add_parser('drop', help='Drop a specific cache')
+    drop_parser.add_argument('site_id', type=int, help='Site ID')
+    drop_parser.add_argument('year', type=int, help='Year')
+
+    # Drop all command
+    subparsers.add_parser('drop-all', help='Drop all caches')
+
+    # Stats command
+    stats_parser = subparsers.add_parser('stats', help='Get cache statistics')
+    stats_parser.add_argument('site_id', type=int, help='Site ID')
+    stats_parser.add_argument('year', type=int, help='Year')
+
+    # Refresh site command
+    refresh_site_parser = subparsers.add_parser('refresh-site', help='Refresh all caches for a site')
+    refresh_site_parser.add_argument('site_id', type=int, help='Site ID')
+    refresh_site_parser.add_argument('--start-year', type=int, help='Start year (default: 2020)')
+    refresh_site_parser.add_argument('--end-year', type=int, help='End year (default: current year)')
+
+    args = parser.parse_args()
+
+    if not args.command:
+        parser.print_help()
+        sys.exit(1)
+
+    try:
+        with RecordsCacheManager() as manager:
+            if args.command == 'setup':
+                manager.create_refresh_function()
+
+            elif args.command == 'refresh':
+                manager.refresh_cache(args.site_id, args.year)
+
+            elif args.command == 'list':
+                manager.list_caches()
+
+            elif args.command == 'drop':
+                manager.drop_cache(args.site_id, args.year)
+
+            elif args.command == 'drop-all':
+                confirm = input("Are you sure you want to drop ALL caches? (yes/no): ")
+                if confirm.lower() == 'yes':
+                    manager.drop_all_caches()
+                else:
+                    logger.info("Operation cancelled")
+
+            elif args.command == 'stats':
+                manager.get_cache_stats(args.site_id, args.year)
+
+            elif args.command == 'refresh-site':
+                manager.refresh_all_for_site(
+                    args.site_id,
+                    args.start_year,
+                    args.end_year
+                )
+
+        logger.info("Operation completed successfully")
+
+    except Exception as e:
+        logger.error(f"Operation failed: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/src/backend/worker/tasks/model_inference_site_task.py
+++ b/backend/src/backend/worker/tasks/model_inference_site_task.py
@@ -4,7 +4,7 @@ import shutil
 import time
 import pandas
 from io import StringIO
-from sqlalchemy import func
+from sqlalchemy import func, text  # Add text import
 from datetime import datetime
 from celery.utils.log import get_task_logger
 from collections import namedtuple
@@ -78,12 +78,12 @@ def model_inference_site_task(
 
         # CRITICAL: Optimize session for bulk inserts on heavily indexed partitioned table
         logger.info("Optimizing database session for bulk inserts")
-        session.execute("SET session_replication_role = replica")  # Skip FK triggers
-        session.execute("SET work_mem = '512MB'")
-        session.execute("SET maintenance_work_mem = '1GB'")
-        session.execute("SET synchronous_commit = OFF")
-        session.execute("SET commit_delay = 100000")
-        session.execute("SET commit_siblings = 5")
+        session.execute(text("SET session_replication_role = replica"))  # Skip FK triggers
+        session.execute(text("SET work_mem = '512MB'"))
+        session.execute(text("SET maintenance_work_mem = '1GB'"))
+        session.execute(text("SET synchronous_commit = OFF"))
+        session.execute(text("SET commit_delay = 100000"))
+        session.execute(text("SET commit_siblings = 5"))
         session.commit()
 
         # detach model from session
@@ -137,12 +137,12 @@ def model_inference_site_task(
             records = (
                 session.query(Records.id, Records.filepath, Records.filename)
                 .outerjoin(
-                    ModelInferenceResults,
-                    (Records.id == ModelInferenceResults.record_id)
-                    & (ModelInferenceResults.model_id == model_id),
+                    ModelInferenceLogs,
+                    (Records.id == ModelInferenceLogs.record_id)
+                    & (ModelInferenceLogs.model_id == model_id),
                 )
                 .filter(Records.site_id == site_id)
-                .filter(ModelInferenceResults.id.is_(None))
+                .filter(ModelInferenceLogs.id.is_(None))
                 .limit(BATCH_SIZE)
                 .all()
             )
@@ -247,7 +247,7 @@ def model_inference_site_task(
             # COPY from buffer to table (bypasses most index overhead)
             cursor.copy_expert(
                 """
-                COPY model_inference_results_pt_record
+                COPY model_inference_results_write
                 (record_id, model_id, start_time, end_time, confidence, label_id)
                 FROM STDIN WITH (FORMAT csv, DELIMITER E'\\t', NULL '\\N')
                 """,
@@ -275,18 +275,19 @@ def model_inference_site_task(
                 logs_buffer
             )
 
+            cursor.close()
             session.commit()
             session.close()
             db_session.remove()
             session = db_session()
 
             # Re-apply session optimizations after reconnecting
-            session.execute("SET session_replication_role = replica")
-            session.execute("SET work_mem = '512MB'")
-            session.execute("SET maintenance_work_mem = '1GB'")
-            session.execute("SET synchronous_commit = OFF")
-            session.execute("SET commit_delay = 100000")
-            session.execute("SET commit_siblings = 5")
+            session.execute(text("SET session_replication_role = replica"))
+            session.execute(text("SET work_mem = '512MB'"))
+            session.execute(text("SET maintenance_work_mem = '1GB'"))
+            session.execute(text("SET synchronous_commit = OFF"))
+            session.execute(text("SET commit_delay = 100000"))
+            session.execute(text("SET commit_siblings = 5"))
             session.commit()
 
             file_counter += len(records)
@@ -309,12 +310,13 @@ def model_inference_site_task(
     finally:
         # Re-enable normal operation
         try:
-            session.execute("SET session_replication_role = DEFAULT")
+            session.execute(text("SET session_replication_role = DEFAULT"))
             session.commit()
         except:
             pass
-        # Uncomment this when you're ready to clean up
-        shutil.rmtree(job_temp_dir)
+        # Clean up temp directory only if it exists
+        if os.path.exists(job_temp_dir):
+            shutil.rmtree(job_temp_dir)
 
     return {
         "status": "success",

--- a/backend/src/backend/worker/tasks/model_inference_site_task.py
+++ b/backend/src/backend/worker/tasks/model_inference_site_task.py
@@ -234,48 +234,101 @@ def model_inference_site_task(
             # Select and reorder columns for insertion
             df_results = df[["record_id", "model_id", "start_time", "end_time", "confidence", "label_id"]]
 
-            # Use COPY for maximum speed (10-50x faster than INSERT on indexed tables)
-            logger.info(f"Inserting {len(df_results)} results using COPY")
+            # Determine partition range for partition-aware operations
+            min_record_id = df_results["record_id"].min()
+            max_record_id = df_results["record_id"].max()
+
+            # Calculate partition numbers (assuming 25000 records per partition based on your schema)
+            min_partition = (min_record_id // 25000) + 1
+            max_partition = (max_record_id // 25000) + 1
+
+            logger.info(f"Inserting {len(df_results)} results across partitions p{min_partition:03d} to p{max_partition:03d}")
+
             connection = session.connection().connection
             cursor = connection.cursor()
 
-            # Create CSV buffer in memory
-            buffer = StringIO()
-            df_results.to_csv(buffer, index=False, header=False, sep='\t', na_rep='\\N')
-            buffer.seek(0)
-
-            # COPY from buffer to table (bypasses most index overhead)
-            cursor.copy_expert(
-                """
-                COPY model_inference_results
-                (record_id, model_id, start_time, end_time, confidence, label_id)
-                FROM STDIN WITH (FORMAT csv, DELIMITER E'\\t', NULL '\\N')
-                """,
-                buffer
-            )
-
-            # Insert logs using COPY
-            logs_df = pandas.DataFrame({
-                "model_id": model_id,
-                "record_id": sorted(df["record_id"].unique()),
-                "analyzed": True
-            })
-
-            logger.info(f"Inserting {len(logs_df)} logs using COPY")
-            logs_buffer = StringIO()
-            logs_df.to_csv(logs_buffer, index=False, header=False, sep='\t')
-            logs_buffer.seek(0)
-
-            cursor.copy_expert(
-                """
-                COPY model_inference_logs
-                (model_id, record_id, analyzed)
-                FROM STDIN WITH (FORMAT csv, DELIMITER E'\\t')
-                """,
-                logs_buffer
-            )
+            # Disable indexes on affected partitions for faster inserts
+            partitions_to_optimize = range(min_partition, max_partition + 1)
+            for partition_num in partitions_to_optimize:
+                partition_name = f"mir_partitions.model_inference_results_p{partition_num:03d}"
+                logger.info(f"Disabling indexes on partition {partition_name}")
+                try:
+                    cursor.execute(f"ALTER TABLE {partition_name} SET UNLOGGED")  # Faster than disabling indexes
+                except Exception as e:
+                    logger.warning(f"Could not set {partition_name} to UNLOGGED: {e}")
 
             session.commit()
+
+            try:
+                # If data fits in a single partition, use partition-aware COPY
+                if min_partition == max_partition:
+                    partition_name = f"mir_partitions.model_inference_results_p{min_partition:03d}"
+                    logger.info(f"Using partition-aware COPY to {partition_name}")
+
+                    buffer = StringIO()
+                    df_results.to_csv(buffer, index=False, header=False, sep='\t', na_rep='\\N')
+                    buffer.seek(0)
+
+                    cursor.copy_expert(
+                        f"""
+                        COPY {partition_name}
+                        (record_id, model_id, start_time, end_time, confidence, label_id)
+                        FROM STDIN WITH (FORMAT csv, DELIMITER E'\\t', NULL '\\N')
+                        """,
+                        buffer
+                    )
+                else:
+                    # Multiple partitions: use parent table COPY
+                    logger.info("Using parent table COPY (multiple partitions)")
+
+                    buffer = StringIO()
+                    df_results.to_csv(buffer, index=False, header=False, sep='\t', na_rep='\\N')
+                    buffer.seek(0)
+
+                    cursor.copy_expert(
+                        """
+                        COPY model_inference_results
+                        (record_id, model_id, start_time, end_time, confidence, label_id)
+                        FROM STDIN WITH (FORMAT csv, DELIMITER E'\\t', NULL '\\N')
+                        """,
+                        buffer
+                    )
+
+                # Insert logs using COPY
+                logs_df = pandas.DataFrame({
+                    "model_id": model_id,
+                    "record_id": sorted(df["record_id"].unique()),
+                    "analyzed": True
+                })
+
+                logger.info(f"Inserting {len(logs_df)} logs using COPY")
+                logs_buffer = StringIO()
+                logs_df.to_csv(logs_buffer, index=False, header=False, sep='\t')
+                logs_buffer.seek(0)
+
+                cursor.copy_expert(
+                    """
+                    COPY model_inference_logs
+                    (model_id, record_id, analyzed)
+                    FROM STDIN WITH (FORMAT csv, DELIMITER E'\\t')
+                    """,
+                    logs_buffer
+                )
+
+                session.commit()
+
+            finally:
+                # Re-enable indexes/logging on affected partitions
+                for partition_num in partitions_to_optimize:
+                    partition_name = f"mir_partitions.model_inference_results_p{partition_num:03d}"
+                    logger.info(f"Re-enabling indexes on partition {partition_name}")
+                    try:
+                        cursor.execute(f"ALTER TABLE {partition_name} SET LOGGED")
+                    except Exception as e:
+                        logger.warning(f"Could not set {partition_name} to LOGGED: {e}")
+
+                session.commit()
+
             session.close()
             db_session.remove()
             session = db_session()

--- a/backend/src/backend/worker/tasks/model_inference_site_task.py
+++ b/backend/src/backend/worker/tasks/model_inference_site_task.py
@@ -206,34 +206,48 @@ def model_inference_site_task(
             df = pandas.read_pickle(os.path.join(job_temp_dir, "output.pkl"))
             # if confidence is 0 or below confidence resolution
             df = df[df["confidence"] >= 0.01]
+            if len(df) == 0:
+                # No results to insert, skip to next batch
+                continue
 
-            # Prepare ModelInferenceResults objects
-            results = []
-            for _, row in df.iterrows():
-                results.append({
-                    "record_id": record_name_to_id[row["filename"]],
-                    "model_id": model_id,
-                    "start_time": row["start_time"],
-                    "end_time": row["end_time"],
-                    "confidence": row["confidence"],
-                    "label_id": row["label_id"],
-                })
-            # Bulk insert results using mappings (faster than bulk_save_objects)
-            if results:
-                session.bulk_insert_mappings(ModelInferenceResults, results)
+            # Map filename to record_id and add model_id
+            df["record_id"] = df["filename"].map(record_name_to_id)
+            df["model_id"] = model_id
 
-            # Prepare ModelInferenceLogs objects
-            unique_filenames = df["filename"].unique()
-            logs = [
-                {
-                    "model_id": model_id,
-                    "record_id": record_name_to_id[filename],
-                    "analyzed": True,
-                }
-                for filename in unique_filenames
-            ]
-            if logs:
-                session.bulk_insert_mappings(ModelInferenceLogs, logs)
+            # CRITICAL: Sort by record_id for partition efficiency
+            # This ensures inserts go to the same partition sequentially,
+            # reducing partition switching overhead and improving cache utilization
+            df = df.sort_values("record_id")
+
+            # Select and reorder columns for insertion
+            df_results = df[["record_id", "model_id", "start_time", "end_time", "confidence", "label_id"]]
+
+            # Use pandas to_sql for fast bulk insert with multi-row statements
+            df_results.to_sql(
+                "model_inference_results",
+                con=session.connection(),
+                if_exists="append",
+                index=False,
+                method="multi",  # Use multi-row INSERT statements
+                chunksize=1000   # Insert 1000 rows per statement
+            )
+
+            # Insert logs - also sort by record_id for consistency
+            logs_df = pandas.DataFrame({
+                "model_id": model_id,
+                "record_id": sorted(df["record_id"].unique()),  # Sort for partition efficiency
+                "analyzed": True
+            })
+
+            logs_df.to_sql(
+                "model_inference_logs",
+                con=session.connection(),
+                if_exists="append",
+                index=False,
+                method="multi",
+                chunksize=1000
+            )
+
             session.commit()
             session.close()
             db_session.remove()

--- a/backend/src/backend/worker/tasks/model_inference_site_task.py
+++ b/backend/src/backend/worker/tasks/model_inference_site_task.py
@@ -3,6 +3,7 @@ import subprocess
 import shutil
 import time
 import pandas
+from io import StringIO
 from sqlalchemy import func
 from datetime import datetime
 from celery.utils.log import get_task_logger
@@ -32,7 +33,7 @@ settings = WorkerSettings()
 logger.setLevel(settings.log_level)
 
 
-BATCH_SIZE = 100
+BATCH_SIZE = 1000  # Increased from 100 for better throughput
 
 
 @app.task(
@@ -74,6 +75,17 @@ def model_inference_site_task(
 
         if not model:
             raise Exception(f"Model {model_id} not found")
+
+        # CRITICAL: Optimize session for bulk inserts on heavily indexed partitioned table
+        logger.info("Optimizing database session for bulk inserts")
+        session.execute("SET session_replication_role = replica")  # Skip FK triggers
+        session.execute("SET work_mem = '512MB'")
+        session.execute("SET maintenance_work_mem = '1GB'")
+        session.execute("SET synchronous_commit = OFF")
+        session.execute("SET commit_delay = 100000")
+        session.execute("SET commit_siblings = 5")
+        session.commit()
+
         # detach model from session
         ModelData = namedtuple(
             "ModelData",
@@ -222,36 +234,61 @@ def model_inference_site_task(
             # Select and reorder columns for insertion
             df_results = df[["record_id", "model_id", "start_time", "end_time", "confidence", "label_id"]]
 
-            # Use pandas to_sql for fast bulk insert with multi-row statements
-            df_results.to_sql(
-                "model_inference_results",
-                con=session.connection(),
-                if_exists="append",
-                index=False,
-                method="multi",  # Use multi-row INSERT statements
-                chunksize=1000   # Insert 1000 rows per statement
+            # Use COPY for maximum speed (10-50x faster than INSERT on indexed tables)
+            logger.info(f"Inserting {len(df_results)} results using COPY")
+            connection = session.connection().connection
+            cursor = connection.cursor()
+
+            # Create CSV buffer in memory
+            buffer = StringIO()
+            df_results.to_csv(buffer, index=False, header=False, sep='\t', na_rep='\\N')
+            buffer.seek(0)
+
+            # COPY from buffer to table (bypasses most index overhead)
+            cursor.copy_expert(
+                """
+                COPY model_inference_results
+                (record_id, model_id, start_time, end_time, confidence, label_id)
+                FROM STDIN WITH (FORMAT csv, DELIMITER E'\\t', NULL '\\N')
+                """,
+                buffer
             )
 
-            # Insert logs - also sort by record_id for consistency
+            # Insert logs using COPY
             logs_df = pandas.DataFrame({
                 "model_id": model_id,
-                "record_id": sorted(df["record_id"].unique()),  # Sort for partition efficiency
+                "record_id": sorted(df["record_id"].unique()),
                 "analyzed": True
             })
 
-            logs_df.to_sql(
-                "model_inference_logs",
-                con=session.connection(),
-                if_exists="append",
-                index=False,
-                method="multi",
-                chunksize=1000
+            logger.info(f"Inserting {len(logs_df)} logs using COPY")
+            logs_buffer = StringIO()
+            logs_df.to_csv(logs_buffer, index=False, header=False, sep='\t')
+            logs_buffer.seek(0)
+
+            cursor.copy_expert(
+                """
+                COPY model_inference_logs
+                (model_id, record_id, analyzed)
+                FROM STDIN WITH (FORMAT csv, DELIMITER E'\\t')
+                """,
+                logs_buffer
             )
 
             session.commit()
             session.close()
             db_session.remove()
             session = db_session()
+
+            # Re-apply session optimizations after reconnecting
+            session.execute("SET session_replication_role = replica")
+            session.execute("SET work_mem = '512MB'")
+            session.execute("SET maintenance_work_mem = '1GB'")
+            session.execute("SET synchronous_commit = OFF")
+            session.execute("SET commit_delay = 100000")
+            session.execute("SET commit_siblings = 5")
+            session.commit()
+
             file_counter += len(records)
 
             JobService.update_job_progress_by_counter(
@@ -261,6 +298,7 @@ def model_inference_site_task(
             for file in os.listdir(job_temp_dir):
                 os.remove(os.path.join(job_temp_dir, file))
             JobService.updateResult(session, job_id, {"inferred_records": file_counter})
+
         JobService.update_job_progress(session, job_id, 100)
 
     except Exception as e:
@@ -269,9 +307,15 @@ def model_inference_site_task(
         logger.error(f"Task failed: {str(e)}")
         raise e
     finally:
+        # Re-enable normal operation
+        try:
+            session.execute("SET session_replication_role = DEFAULT")
+            session.commit()
+        except:
+            pass
         # Uncomment this when you're ready to clean up
-
         shutil.rmtree(job_temp_dir)
+
     return {
         "status": "success",
         "message": f"Successfully analyzed {file_counter} records for site {site_id}",

--- a/backend/src/backend/worker/tasks/model_inference_site_task.py
+++ b/backend/src/backend/worker/tasks/model_inference_site_task.py
@@ -4,7 +4,7 @@ import shutil
 import time
 import pandas
 from io import StringIO
-from sqlalchemy import func
+from sqlalchemy import func, text
 from datetime import datetime
 from celery.utils.log import get_task_logger
 from collections import namedtuple
@@ -78,12 +78,12 @@ def model_inference_site_task(
 
         # CRITICAL: Optimize session for bulk inserts on heavily indexed partitioned table
         logger.info("Optimizing database session for bulk inserts")
-        session.execute("SET session_replication_role = replica")  # Skip FK triggers
-        session.execute("SET work_mem = '512MB'")
-        session.execute("SET maintenance_work_mem = '1GB'")
-        session.execute("SET synchronous_commit = OFF")
-        session.execute("SET commit_delay = 100000")
-        session.execute("SET commit_siblings = 5")
+        session.execute(text("SET session_replication_role = replica"))  # Skip FK triggers
+        session.execute(text("SET work_mem = '512MB'"))
+        session.execute(text("SET maintenance_work_mem = '1GB'"))
+        session.execute(text("SET synchronous_commit = OFF"))
+        session.execute(text("SET commit_delay = 100000"))
+        session.execute(text("SET commit_siblings = 5"))
         session.commit()
 
         # detach model from session
@@ -281,12 +281,12 @@ def model_inference_site_task(
             session = db_session()
 
             # Re-apply session optimizations after reconnecting
-            session.execute("SET session_replication_role = replica")
-            session.execute("SET work_mem = '512MB'")
-            session.execute("SET maintenance_work_mem = '1GB'")
-            session.execute("SET synchronous_commit = OFF")
-            session.execute("SET commit_delay = 100000")
-            session.execute("SET commit_siblings = 5")
+            session.execute(text("SET session_replication_role = replica"))
+            session.execute(text("SET work_mem = '512MB'"))
+            session.execute(text("SET maintenance_work_mem = '1GB'"))
+            session.execute(text("SET synchronous_commit = OFF"))
+            session.execute(text("SET commit_delay = 100000"))
+            session.execute(text("SET commit_siblings = 5"))
             session.commit()
 
             file_counter += len(records)
@@ -309,12 +309,13 @@ def model_inference_site_task(
     finally:
         # Re-enable normal operation
         try:
-            session.execute("SET session_replication_role = DEFAULT")
+            session.execute(text("SET session_replication_role = DEFAULT"))
             session.commit()
         except:
             pass
-        # Uncomment this when you're ready to clean up
-        shutil.rmtree(job_temp_dir)
+        # Clean up temp directory only if it exists
+        if os.path.exists(job_temp_dir):
+            shutil.rmtree(job_temp_dir)
 
     return {
         "status": "success",

--- a/backend/src/backend/worker/tasks/model_inference_site_task.py
+++ b/backend/src/backend/worker/tasks/model_inference_site_task.py
@@ -4,7 +4,7 @@ import shutil
 import time
 import pandas
 from io import StringIO
-from sqlalchemy import func, text
+from sqlalchemy import func
 from datetime import datetime
 from celery.utils.log import get_task_logger
 from collections import namedtuple
@@ -78,12 +78,12 @@ def model_inference_site_task(
 
         # CRITICAL: Optimize session for bulk inserts on heavily indexed partitioned table
         logger.info("Optimizing database session for bulk inserts")
-        session.execute(text("SET session_replication_role = replica"))  # Skip FK triggers
-        session.execute(text("SET work_mem = '512MB'"))
-        session.execute(text("SET maintenance_work_mem = '1GB'"))
-        session.execute(text("SET synchronous_commit = OFF"))
-        session.execute(text("SET commit_delay = 100000"))
-        session.execute(text("SET commit_siblings = 5"))
+        session.execute("SET session_replication_role = replica")  # Skip FK triggers
+        session.execute("SET work_mem = '512MB'")
+        session.execute("SET maintenance_work_mem = '1GB'")
+        session.execute("SET synchronous_commit = OFF")
+        session.execute("SET commit_delay = 100000")
+        session.execute("SET commit_siblings = 5")
         session.commit()
 
         # detach model from session
@@ -137,12 +137,12 @@ def model_inference_site_task(
             records = (
                 session.query(Records.id, Records.filepath, Records.filename)
                 .outerjoin(
-                    ModelInferenceLogs,  # ✅ Changed from ModelInferenceResults
-                    (Records.id == ModelInferenceLogs.record_id)
-                    & (ModelInferenceLogs.model_id == model_id),
+                    ModelInferenceResults,
+                    (Records.id == ModelInferenceResults.record_id)
+                    & (ModelInferenceResults.model_id == model_id),
                 )
                 .filter(Records.site_id == site_id)
-                .filter(ModelInferenceLogs.id.is_(None))  # ✅ Changed from ModelInferenceResults
+                .filter(ModelInferenceResults.id.is_(None))
                 .limit(BATCH_SIZE)
                 .all()
             )
@@ -234,138 +234,59 @@ def model_inference_site_task(
             # Select and reorder columns for insertion
             df_results = df[["record_id", "model_id", "start_time", "end_time", "confidence", "label_id"]]
 
-            # Determine partition range for partition-aware operations
-            min_record_id = df_results["record_id"].min()
-            max_record_id = df_results["record_id"].max()
-
-            # Calculate partition numbers (assuming 25000 records per partition based on your schema)
-            min_partition = (min_record_id // 25000) + 1
-            max_partition = (max_record_id // 25000) + 1
-
-            logger.info(f"Inserting {len(df_results)} results across partitions p{min_partition:03d} to p{max_partition:03d}")
-
+            # Use COPY for maximum speed (10-50x faster than INSERT on indexed tables)
+            logger.info(f"Inserting {len(df_results)} results using COPY")
             connection = session.connection().connection
+            cursor = connection.cursor()
 
-            # Disable indexes on affected partitions for faster inserts
-            partitions_to_optimize = list(range(min_partition, max_partition + 1))
-            for partition_num in partitions_to_optimize:
-                partition_name = f"mir_partitions.model_inference_results_p{partition_num:03d}"
-                logger.info(f"Setting partition {partition_name} to UNLOGGED")
-                try:
-                    # Create new cursor for each DDL operation
-                    cursor = connection.cursor()
-                    cursor.execute(f"ALTER TABLE {partition_name} SET UNLOGGED")
-                    cursor.close()
-                    connection.commit()
-                except Exception as e:
-                    logger.warning(f"Could not set {partition_name} to UNLOGGED: {e}")
+            # Create CSV buffer in memory
+            buffer = StringIO()
+            df_results.to_csv(buffer, index=False, header=False, sep='\t', na_rep='\\N')
+            buffer.seek(0)
 
-            try:
-                # Create fresh cursor for COPY operations
-                cursor = connection.cursor()
+            # COPY from buffer to table (bypasses most index overhead)
+            cursor.copy_expert(
+                """
+                COPY model_inference_results_pt_record
+                (record_id, model_id, start_time, end_time, confidence, label_id)
+                FROM STDIN WITH (FORMAT csv, DELIMITER E'\\t', NULL '\\N')
+                """,
+                buffer
+            )
 
-                # If data fits in a single partition, use partition-aware COPY
-                if min_partition == max_partition:
-                    partition_name = f"mir_partitions.model_inference_results_p{min_partition:03d}"
-                    logger.info(f"Using partition-aware COPY to {partition_name}")
+            # Insert logs using COPY
+            logs_df = pandas.DataFrame({
+                "model_id": model_id,
+                "record_id": sorted(df["record_id"].unique()),
+                "analyzed": True
+            })
 
-                    buffer = StringIO()
-                    df_results.to_csv(buffer, index=False, header=False, sep='\t', na_rep='\\N')
-                    buffer.seek(0)
+            logger.info(f"Inserting {len(logs_df)} logs using COPY")
+            logs_buffer = StringIO()
+            logs_df.to_csv(logs_buffer, index=False, header=False, sep='\t')
+            logs_buffer.seek(0)
 
-                    cursor.copy_expert(
-                        f"""
-                        COPY {partition_name}
-                        (record_id, model_id, start_time, end_time, confidence, label_id)
-                        FROM STDIN WITH (FORMAT csv, DELIMITER E'\\t', NULL '\\N')
-                        """,
-                        buffer
-                    )
-                else:
-                    # Multiple partitions: use parent table COPY
-                    logger.info("Using parent table COPY (multiple partitions)")
+            cursor.copy_expert(
+                """
+                COPY model_inference_logs
+                (model_id, record_id, analyzed)
+                FROM STDIN WITH (FORMAT csv, DELIMITER E'\\t')
+                """,
+                logs_buffer
+            )
 
-                    buffer = StringIO()
-                    df_results.to_csv(buffer, index=False, header=False, sep='\t', na_rep='\\N')
-                    buffer.seek(0)
-
-                    cursor.copy_expert(
-                        """
-                        COPY model_inference_results
-                        (record_id, model_id, start_time, end_time, confidence, label_id)
-                        FROM STDIN WITH (FORMAT csv, DELIMITER E'\\t', NULL '\\N')
-                        """,
-                        buffer
-                    )
-
-                # Insert logs using COPY with ON CONFLICT handling
-                logs_df = pandas.DataFrame({
-                    "model_id": model_id,
-                    "record_id": sorted(df["record_id"].unique()),
-                    "analyzed": True
-                })
-
-                logger.info(f"Inserting {len(logs_df)} logs using COPY")
-
-                # Create temporary table for logs
-                cursor.execute("""
-                    CREATE TEMPORARY TABLE temp_model_inference_logs (
-                        model_id INTEGER,
-                        record_id BIGINT,
-                        analyzed BOOLEAN
-                    ) ON COMMIT DROP
-                """)
-
-                # COPY into temporary table
-                logs_buffer = StringIO()
-                logs_df.to_csv(logs_buffer, index=False, header=False, sep='\t')
-                logs_buffer.seek(0)
-
-                cursor.copy_expert(
-                    """
-                    COPY temp_model_inference_logs
-                    (model_id, record_id, analyzed)
-                    FROM STDIN WITH (FORMAT csv, DELIMITER E'\\t')
-                    """,
-                    logs_buffer
-                )
-
-                # Insert from temp table with ON CONFLICT DO NOTHING
-                cursor.execute("""
-                    INSERT INTO model_inference_logs (model_id, record_id, analyzed)
-                    SELECT model_id, record_id, analyzed
-                    FROM temp_model_inference_logs
-                    ON CONFLICT (model_id, record_id) DO NOTHING
-                """)
-
-                cursor.close()
-                connection.commit()
-
-            finally:
-                # Re-enable indexes/logging on affected partitions
-                for partition_num in partitions_to_optimize:
-                    partition_name = f"mir_partitions.model_inference_results_p{partition_num:03d}"
-                    logger.info(f"Setting partition {partition_name} back to LOGGED")
-                    try:
-                        # Create new cursor for each DDL operation
-                        cursor = connection.cursor()
-                        cursor.execute(f"ALTER TABLE {partition_name} SET LOGGED")
-                        cursor.close()
-                        connection.commit()
-                    except Exception as e:
-                        logger.warning(f"Could not set {partition_name} to LOGGED: {e}")
-
+            session.commit()
             session.close()
             db_session.remove()
             session = db_session()
 
             # Re-apply session optimizations after reconnecting
-            session.execute(text("SET session_replication_role = replica"))
-            session.execute(text("SET work_mem = '512MB'"))
-            session.execute(text("SET maintenance_work_mem = '1GB'"))
-            session.execute(text("SET synchronous_commit = OFF"))
-            session.execute(text("SET commit_delay = 100000"))
-            session.execute(text("SET commit_siblings = 5"))
+            session.execute("SET session_replication_role = replica")
+            session.execute("SET work_mem = '512MB'")
+            session.execute("SET maintenance_work_mem = '1GB'")
+            session.execute("SET synchronous_commit = OFF")
+            session.execute("SET commit_delay = 100000")
+            session.execute("SET commit_siblings = 5")
             session.commit()
 
             file_counter += len(records)
@@ -388,13 +309,12 @@ def model_inference_site_task(
     finally:
         # Re-enable normal operation
         try:
-            session.execute(text("SET session_replication_role = DEFAULT"))
+            session.execute("SET session_replication_role = DEFAULT")
             session.commit()
         except:
             pass
-        # Clean up temp directory only if it exists
-        if os.path.exists(job_temp_dir):
-            shutil.rmtree(job_temp_dir)
+        # Uncomment this when you're ready to clean up
+        shutil.rmtree(job_temp_dir)
 
     return {
         "status": "success",

--- a/backend/src/backend/worker/tasks/model_inference_site_task.py
+++ b/backend/src/backend/worker/tasks/model_inference_site_task.py
@@ -245,21 +245,25 @@ def model_inference_site_task(
             logger.info(f"Inserting {len(df_results)} results across partitions p{min_partition:03d} to p{max_partition:03d}")
 
             connection = session.connection().connection
-            cursor = connection.cursor()
 
             # Disable indexes on affected partitions for faster inserts
-            partitions_to_optimize = range(min_partition, max_partition + 1)
+            partitions_to_optimize = list(range(min_partition, max_partition + 1))
             for partition_num in partitions_to_optimize:
                 partition_name = f"mir_partitions.model_inference_results_p{partition_num:03d}"
-                logger.info(f"Disabling indexes on partition {partition_name}")
+                logger.info(f"Setting partition {partition_name} to UNLOGGED")
                 try:
-                    cursor.execute(f"ALTER TABLE {partition_name} SET UNLOGGED")  # Faster than disabling indexes
+                    # Create new cursor for each DDL operation
+                    cursor = connection.cursor()
+                    cursor.execute(f"ALTER TABLE {partition_name} SET UNLOGGED")
+                    cursor.close()
+                    connection.commit()
                 except Exception as e:
                     logger.warning(f"Could not set {partition_name} to UNLOGGED: {e}")
 
-            session.commit()
-
             try:
+                # Create fresh cursor for COPY operations
+                cursor = connection.cursor()
+
                 # If data fits in a single partition, use partition-aware COPY
                 if min_partition == max_partition:
                     partition_name = f"mir_partitions.model_inference_results_p{min_partition:03d}"
@@ -315,19 +319,22 @@ def model_inference_site_task(
                     logs_buffer
                 )
 
-                session.commit()
+                cursor.close()
+                connection.commit()
 
             finally:
                 # Re-enable indexes/logging on affected partitions
                 for partition_num in partitions_to_optimize:
                     partition_name = f"mir_partitions.model_inference_results_p{partition_num:03d}"
-                    logger.info(f"Re-enabling indexes on partition {partition_name}")
+                    logger.info(f"Setting partition {partition_name} back to LOGGED")
                     try:
+                        # Create new cursor for each DDL operation
+                        cursor = connection.cursor()
                         cursor.execute(f"ALTER TABLE {partition_name} SET LOGGED")
+                        cursor.close()
+                        connection.commit()
                     except Exception as e:
                         logger.warning(f"Could not set {partition_name} to LOGGED: {e}")
-
-                session.commit()
 
             session.close()
             db_session.remove()

--- a/backend/src/backend/worker/tasks/model_inference_site_task.py
+++ b/backend/src/backend/worker/tasks/model_inference_site_task.py
@@ -137,12 +137,12 @@ def model_inference_site_task(
             records = (
                 session.query(Records.id, Records.filepath, Records.filename)
                 .outerjoin(
-                    ModelInferenceResults,
-                    (Records.id == ModelInferenceResults.record_id)
-                    & (ModelInferenceResults.model_id == model_id),
+                    ModelInferenceLogs,  # ✅ Changed from ModelInferenceResults
+                    (Records.id == ModelInferenceLogs.record_id)
+                    & (ModelInferenceLogs.model_id == model_id),
                 )
                 .filter(Records.site_id == site_id)
-                .filter(ModelInferenceResults.id.is_(None))
+                .filter(ModelInferenceLogs.id.is_(None))  # ✅ Changed from ModelInferenceResults
                 .limit(BATCH_SIZE)
                 .all()
             )
@@ -298,7 +298,7 @@ def model_inference_site_task(
                         buffer
                     )
 
-                # Insert logs using COPY
+                # Insert logs using COPY with ON CONFLICT handling
                 logs_df = pandas.DataFrame({
                     "model_id": model_id,
                     "record_id": sorted(df["record_id"].unique()),
@@ -306,18 +306,37 @@ def model_inference_site_task(
                 })
 
                 logger.info(f"Inserting {len(logs_df)} logs using COPY")
+
+                # Create temporary table for logs
+                cursor.execute("""
+                    CREATE TEMPORARY TABLE temp_model_inference_logs (
+                        model_id INTEGER,
+                        record_id BIGINT,
+                        analyzed BOOLEAN
+                    ) ON COMMIT DROP
+                """)
+
+                # COPY into temporary table
                 logs_buffer = StringIO()
                 logs_df.to_csv(logs_buffer, index=False, header=False, sep='\t')
                 logs_buffer.seek(0)
 
                 cursor.copy_expert(
                     """
-                    COPY model_inference_logs
+                    COPY temp_model_inference_logs
                     (model_id, record_id, analyzed)
                     FROM STDIN WITH (FORMAT csv, DELIMITER E'\\t')
                     """,
                     logs_buffer
                 )
+
+                # Insert from temp table with ON CONFLICT DO NOTHING
+                cursor.execute("""
+                    INSERT INTO model_inference_logs (model_id, record_id, analyzed)
+                    SELECT model_id, record_id, analyzed
+                    FROM temp_model_inference_logs
+                    ON CONFLICT (model_id, record_id) DO NOTHING
+                """)
 
                 cursor.close()
                 connection.commit()

--- a/backend/src/backend/worker/tasks/model_inference_site_task.py
+++ b/backend/src/backend/worker/tasks/model_inference_site_task.py
@@ -247,7 +247,7 @@ def model_inference_site_task(
             # COPY from buffer to table (bypasses most index overhead)
             cursor.copy_expert(
                 """
-                COPY model_inference_results_write
+                COPY model_inference_results_pt_record
                 (record_id, model_id, start_time, end_time, confidence, label_id)
                 FROM STDIN WITH (FORMAT csv, DELIMITER E'\\t', NULL '\\N')
                 """,

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -2198,15 +2198,9 @@ unique or primary key constraints on table "model_inference_results"
 """
 enum model_inference_results_constraint {
   """
-<<<<<<< HEAD
-  unique or primary key constraint on columns "id", "site_id"
-  """
-  model_inference_results_new_pkey
-=======
   unique or primary key constraint on columns "id", "record_id"
   """
   model_inference_results_pt_record_pkey
->>>>>>> partition
 }
 
 """
@@ -2302,11 +2296,7 @@ input model_inference_results_order_by {
 """primary key columns input for table: model_inference_results"""
 input model_inference_results_pk_columns_input {
   id: bigint!
-<<<<<<< HEAD
-  site_id: bigint!
-=======
   record_id: bigint!
->>>>>>> partition
 }
 
 """
@@ -3377,11 +3367,7 @@ type mutation_root {
   """
   delete single row from the table: "model_inference_results"
   """
-<<<<<<< HEAD
-  delete_model_inference_results_by_pk(id: bigint!, site_id: bigint!): model_inference_results
-=======
   delete_model_inference_results_by_pk(id: bigint!, record_id: bigint!): model_inference_results
->>>>>>> partition
 
   """
   delete data from the table: "model_labels"
@@ -4770,11 +4756,7 @@ type query_root {
   """
   fetch data from the table: "model_inference_results" using primary key columns
   """
-<<<<<<< HEAD
-  model_inference_results_by_pk(id: bigint!, site_id: bigint!): model_inference_results
-=======
   model_inference_results_by_pk(id: bigint!, record_id: bigint!): model_inference_results
->>>>>>> partition
 
   """An array relationship"""
   model_labels(
@@ -9120,11 +9102,7 @@ type subscription_root {
   """
   fetch data from the table: "model_inference_results" using primary key columns
   """
-<<<<<<< HEAD
-  model_inference_results_by_pk(id: bigint!, site_id: bigint!): model_inference_results
-=======
   model_inference_results_by_pk(id: bigint!, record_id: bigint!): model_inference_results
->>>>>>> partition
 
   """
   fetch data from the table in a streaming manner: "model_inference_results"
@@ -9665,4 +9643,3 @@ input timestamptz_comparison_exp {
   _neq: timestamptz
   _nin: [timestamptz!]
 }
-

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -2195,9 +2195,9 @@ unique or primary key constraints on table "model_inference_results"
 """
 enum model_inference_results_constraint {
   """
-  unique or primary key constraint on columns "id"
+  unique or primary key constraint on columns "id", "record_id"
   """
-  model_inference_results_pkey
+  model_inference_results_pt_record_pkey
 }
 
 """
@@ -2288,6 +2288,7 @@ input model_inference_results_order_by {
 """primary key columns input for table: model_inference_results"""
 input model_inference_results_pk_columns_input {
   id: bigint!
+  record_id: bigint!
 }
 
 """
@@ -3343,7 +3344,7 @@ type mutation_root {
   """
   delete single row from the table: "model_inference_results"
   """
-  delete_model_inference_results_by_pk(id: bigint!): model_inference_results
+  delete_model_inference_results_by_pk(id: bigint!, record_id: bigint!): model_inference_results
 
   """
   delete data from the table: "model_labels"
@@ -4732,7 +4733,7 @@ type query_root {
   """
   fetch data from the table: "model_inference_results" using primary key columns
   """
-  model_inference_results_by_pk(id: bigint!): model_inference_results
+  model_inference_results_by_pk(id: bigint!, record_id: bigint!): model_inference_results
 
   """An array relationship"""
   model_labels(
@@ -9078,7 +9079,7 @@ type subscription_root {
   """
   fetch data from the table: "model_inference_results" using primary key columns
   """
-  model_inference_results_by_pk(id: bigint!): model_inference_results
+  model_inference_results_by_pk(id: bigint!, record_id: bigint!): model_inference_results
 
   """
   fetch data from the table in a streaming manner: "model_inference_results"

--- a/frontend/src/components/dashboard/PageControls.vue
+++ b/frontend/src/components/dashboard/PageControls.vue
@@ -37,6 +37,24 @@ const threshold = ref(props.defaultThreshold);
 const isUpdatingThreshold = ref(false);
 let thresholdTimeoutId = null;
 
+/*******************************************
+ * manually maintained lists of
+ * stuff that is ready and can be displayed
+ ******************************************/
+
+ // Manually maintained list of ready site IDs
+const readySiteIds = ref([
+  1, 26, 27, 28, 29, 13, 16, 21, 22, 23, 6, 7, 8, 9
+]);
+
+// Manually maintained list of ready model IDs
+const readyModelIds = ref([
+  3
+]);
+
+/******************
+ * Species logic
+ ******************/
 // Check if the species list contains only a placeholder
 const hasOnlyPlaceholder = computed(() => {
   return props.availableSpecies.length === 1 &&
@@ -107,7 +125,8 @@ const debouncedUpdateSelection = debounce(() => {
 const models = computed(() => {
   return props.availableModels.map(model => ({
     title: model.name,
-    value: model.id
+    value: model.id,
+    isReady: readyModelIds.value.includes(model.id)
   }));
 });
 
@@ -134,10 +153,13 @@ const availableSitesList = computed(() => {
     return [];
   }
 
-  // Filter out sites that are already selected
-  const filtered = props.availableSites.filter(site =>
-    !selectedSites.value.some(s => s.value === site.value)
-  );
+  // Filter out sites that are already selected and add ready status
+  const filtered = props.availableSites
+    .filter(site => !selectedSites.value.some(s => s.value === site.value))
+    .map(site => ({
+      ...site,
+      isReady: readySiteIds.value.includes(site.value)
+    }));
 
   return filtered;
 });
@@ -156,6 +178,10 @@ watch(
 
 // Function to select a site
 function selectSite(site) {
+  // Only allow selection if site is ready
+  if (!site.isReady) {
+    return;
+  }
   selectedSites.value.push(site);  // Set to allow multiple selections
   // selectedSites.value = [site]; // Set to array with only the new site
   // updateSelection();
@@ -305,12 +331,30 @@ watch(
           v-model="selectedModel"
           :items="models"
           item-title="title"
-          item-value="id"
+          item-value="value"
           return-object
           density="compact"
           @update:model-value="updateSelection"
           class="inline-select"
-        ></v-select>
+        >
+          <template v-slot:item="{ props, item }">
+            <v-list-item
+              v-bind="props"
+              :disabled="!item.raw.isReady"
+              :class="{ 'model-not-ready': !item.raw.isReady }"
+            >
+              <template v-slot:append v-if="!item.raw.isReady">
+                <v-chip size="x-small" color="warning" variant="flat">Pending</v-chip>
+              </template>
+            </v-list-item>
+          </template>
+          <template v-slot:selection="{ item }">
+            <span :class="{ 'text-grey': !item.raw.isReady }">
+              {{ item.title }}
+              <v-chip v-if="!item.raw.isReady" size="x-small" color="warning" variant="flat" class="ml-2">Pending</v-chip>
+            </span>
+          </template>
+        </v-select>
       </div>
 
       <!-- Site Lists Container -->
@@ -325,9 +369,13 @@ watch(
                 :key="site.value"
                 :value="site"
                 @click="selectSite(site)"
-                class="site-list-item"
+                :class="['site-list-item', { 'site-not-ready': !site.isReady }]"
+                :disabled="!site.isReady"
               >
                 {{ site.title }}
+                <template v-slot:append v-if="!site.isReady">
+                  <v-chip size="x-small" color="warning" variant="flat">Pending</v-chip>
+                </template>
               </v-list-item>
               <v-list-item v-if="availableSitesList.length === 0">
                 <v-list-item-title class="text-grey">No sites available</v-list-item-title>
@@ -391,8 +439,7 @@ watch(
           hide-details
         ></v-select>
         <!-- Display the appropriate message -->
-        <div v-if="hasOnlyPlaceholder" class="custom-message">
-          {{ placeholderMessage }}
+        <div v-if="hasOnlyPlaceholder" class="custom-message" v-html="placeholderMessage">
         </div>
         <div v-else-if="speciesCountMessage" class="custom-message">
           {{ speciesCountMessage }}
@@ -454,6 +501,24 @@ watch(
 
 .site-list-item {
   cursor: pointer;
+}
+
+.site-list-item.site-not-ready {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.model-not-ready {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.model-not-ready:hover {
+  background-color: transparent !important;
+}
+
+.site-list-item.site-not-ready:hover {
+  background-color: transparent !important;
 }
 
 label {

--- a/frontend/src/composables/api/labels.ts
+++ b/frontend/src/composables/api/labels.ts
@@ -95,15 +95,58 @@ export const useLabelsSearch = () => {
   const data = ref(null);
   let pendingSearch = null;
 
+  // Cache object to store results by key
+  const cache = new Map<string, { labels: any[], timestamp: number }>();
+  const CACHE_TTL = 5 * 60 * 1000; // 5 minutes in milliseconds
+
+  /**
+   * Generate a cache key from the search parameters
+   */
+  const getCacheKey = (modelId: number, siteIds: number[], year: number | string | null) => {
+    const sortedSiteIds = [...siteIds].sort().join(',');
+    return `${modelId}_${sortedSiteIds}_${year}`;
+  };
+
+  /**
+   * Check if cached data is still valid
+   */
+  const isCacheValid = (timestamp: number) => {
+    return Date.now() - timestamp < CACHE_TTL;
+  };
+
   /**
    * Searches for distinct labels based on model_id, site_id and year
+   * Results are cached for 5 minutes
    *
    * @param modelId - The model ID to filter results by
    * @param siteIds - The list of site IDs to filter records by
    * @param year - The year to filter records by (records where record_datetime is in this year)
+   * @param forceRefresh - Force refresh even if cached data exists
    */
-  const searchLabels = async (modelId: number, siteIds: number[], year: number | string | null = null) => {
-    console.log(`searchLabels called with modelId=${modelId}, siteIds=${siteIds}, year=${year}`);
+  const searchLabels = async (
+    modelId: number,
+    siteIds: number[],
+    year: number | string | null = null,
+    forceRefresh: boolean = false
+  ) => {
+    console.log(`searchLabels called with modelId=${modelId}, siteIds=${siteIds}, year=${year}, forceRefresh=${forceRefresh}`);
+
+    // Generate cache key
+    const cacheKey = getCacheKey(modelId, siteIds, year);
+
+    // Check cache first (unless force refresh)
+    if (!forceRefresh && cache.has(cacheKey)) {
+      const cached = cache.get(cacheKey);
+      if (isCacheValid(cached.timestamp)) {
+        console.log(`Returning cached results for key: ${cacheKey}`);
+        data.value = { labels: cached.labels };
+        return;
+      } else {
+        console.log(`Cache expired for key: ${cacheKey}`);
+        cache.delete(cacheKey);
+      }
+    }
+
     pending.value = true;
     error.value = null;
 
@@ -156,13 +199,16 @@ export const useLabelsSearch = () => {
       const recordIds = (recordsResult.data?.records || []).map(r => r.id);
 
       if (recordIds.length === 0) {
-        data.value = { labels: [] };
+        const emptyResult = { labels: [] };
+        data.value = emptyResult;
+        // Cache empty results too
+        cache.set(cacheKey, { labels: [], timestamp: Date.now() });
         return;
       }
 
       console.log(`Found ${recordIds.length} matching records`);
 
-      // Step 2: Query model_inference_results with record_id filter (enables partition pruning!)
+      // Step 2: Query model_inference_results_max_confidence with record_id filter
       const result = await $fetch(config.public.GQL_HOST, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -172,7 +218,7 @@ export const useLabelsSearch = () => {
               $modelId: Int!,
               $recordIds: [bigint!]!
             ) {
-              model_inference_results(
+              model_inference_results_max_confidence(
                 where: {
                   model_id: {_eq: $modelId},
                   record_id: {_in: $recordIds}
@@ -199,11 +245,17 @@ export const useLabelsSearch = () => {
 
       console.log("Raw GraphQL result:", result);
 
-      const labels = (result.data?.model_inference_results || [])
+      const labels = (result.data?.model_inference_results_max_confidence || [])
         .map(mir => mir.label)
         .filter(label => label != null);
 
       labels.sort((a, b) => a.name.localeCompare(b.name));
+
+      console.log("Processed labels:", labels);
+
+      // Store in cache
+      cache.set(cacheKey, { labels, timestamp: Date.now() });
+      console.log(`Cached results for key: ${cacheKey}`);
 
       data.value = { labels };
     } catch (err) {
@@ -218,11 +270,31 @@ export const useLabelsSearch = () => {
       }
     }
   };
+
+  /**
+   * Clear all cached data
+   */
+  const clearCache = () => {
+    cache.clear();
+    console.log('Cache cleared');
+  };
+
+  /**
+   * Clear specific cached entry
+   */
+  const clearCacheEntry = (modelId: number, siteIds: number[], year: number | string | null) => {
+    const cacheKey = getCacheKey(modelId, siteIds, year);
+    cache.delete(cacheKey);
+    console.log(`Cleared cache for key: ${cacheKey}`);
+  };
+
   return {
     data,
     pending,
     error,
     searchLabels,
+    clearCache,
+    clearCacheEntry,
     pendingSearch
   };
 };

--- a/frontend/src/composables/api/labels.ts
+++ b/frontend/src/composables/api/labels.ts
@@ -172,7 +172,7 @@ export const useLabelsSearch = () => {
               $modelId: Int!,
               $recordIds: [bigint!]!
             ) {
-              model_inference_results(
+              model_inference_results_max_confidence(
                 where: {
                   model_id: {_eq: $modelId},
                   record_id: {_in: $recordIds}
@@ -199,7 +199,7 @@ export const useLabelsSearch = () => {
 
       console.log("Raw GraphQL result:", result);
 
-      const labels = (result.data?.model_inference_results || [])
+      const labels = (result.data?.model_inference_results_max_confidence || [])
         .map(mir => mir.label)
         .filter(label => label != null);
 

--- a/frontend/src/pages/dashboard/index.vue
+++ b/frontend/src/pages/dashboard/index.vue
@@ -166,7 +166,8 @@ const formattedSpecies = computed(() => {
 
   if (!speciesData) {
     // Create a placeholder message
-    let message = "Please choose a classifier, a site and a year to display species";
+    // Use an HTML line break; ensure the consumer renders HTML (e.g. v-html) or use CSS white-space if rendering plain text
+    let message = "Please choose a classifier, a site and<br/> a year to display species";
     return [{
       title: message,
       value: null,
@@ -326,7 +327,7 @@ console.log("Initial selectedParams:", selectedParams.value);
                 <v-icon icon="mdi-tune" size="large" color="grey" class="mb-3"></v-icon>
                 <h3 class="text-h5 text-grey-darken-1">Select all parameters to display the dashboard</h3>
                 <p class="text-body-1 text-grey-darken-1">
-                  Please choose a classifier, site, year, and species from the control panel.
+                  Please choose a classifier, site, year, and species from the control panel
                 </p>
               </div>
             </v-card>


### PR DESCRIPTION
Inferences are now written to a table partitioned by record_id with minimal indexing: model_inference_results_pt_record.

For the dashboard, which only displays the maximum confidence per minute and species, values are read from a separate table with primary key (record_id, label_id, model_id): model_inference_results_max_confidence.
This table is much smaller, indexed for fast reads, and contains exactly one value per model/recording/species (the max confidence).

Currently, it is populated by a script that is triggered manually.